### PR TITLE
Column name fixes

### DIFF
--- a/docs/data-models/claims-data-model/01-eligibility.md
+++ b/docs/data-models/claims-data-model/01-eligibility.md
@@ -33,8 +33,8 @@ The eligibility table uses the coverage format because this format is more commo
 | enrollment_end_date | date | no | Date the patient's insurance eligibility ended. |
 | payer | varchar | no | Name of the payer (i.e. health insurer) providing coverage. |
 | payer_type | varchar | [yes](https://github.com/tuva-health/terminology/blob/main/terminology/terminology__payer_type.csv) | Type of payer (e.g. commercial, medicare, medicaid, etc.). |
-| dual_status | varchar | [yes](https://github.com/tuva-health/terminology/blob/main/terminology/terminology__medicare_dual_eligibility.csv) | Indicates whether the patient is dually eligible for Medicare and Medicaid. |
-| medicare_status | varchar | [yes](https://github.com/tuva-health/terminology/blob/main/terminology/terminology__medicare_status.csv) | Indicates how the patient became eligible for Medicare. |
+| dual_status_code | varchar | [yes](https://github.com/tuva-health/terminology/blob/main/terminology/terminology__medicare_dual_eligibility.csv) | Indicates whether the patient is dually eligible for Medicare and Medicaid. |
+| medicare_status_code | varchar | [yes](https://github.com/tuva-health/terminology/blob/main/terminology/terminology__medicare_status.csv) | Indicates how the patient became eligible for Medicare. |
 | first_name | varchar | no | Patient's first name. |
 | last_name | varchar | no | Patient's last name. |
 | address | varchar | no | Patient's street address. |

--- a/docs/data-models/claims-data-model/03-pharmacy-claim.md
+++ b/docs/data-models/claims-data-model/03-pharmacy-claim.md
@@ -14,7 +14,7 @@ The pharmacy_claim table is at the claim-line grain.
 | Column | Data Type | Terminology | Description |
 | --- | :---: | :---: | --- |
 | claim_id | varchar | no | Unique identifier for each claim. |
-| claim_line | int | no | Indicates the line number for the particular line of the claim. |
+| claim_line_number | int | no | Indicates the line number for the particular line of the claim. |
 | patient_id | varchar | no | Unique identifier for each patient in the dataset. |
 | member_id | varchar | no | Identifier that links a patient to a particular insurance product or health plan.  A patient can have more than one member_id because they can have more than one insurance product/plan. |
 | prescribing_provider_npi | varchar | no | NPI for the provider that wrote the prescription (e.g. priamry care physician). |


### PR DESCRIPTION
updated three column names:

- dual_status to dual_status_code  (eligibility)
- medicare_status to medicare_status_code (eligibility)
- claim_line to claim_line_number (pharmacy)