### PR TITLE
added redirect page to preserve old url

### DIFF
--- a/docs/claims-data-warehouse/setup.md
+++ b/docs/claims-data-warehouse/setup.md
@@ -1,0 +1,10 @@
+---
+id: setup
+title: setup
+---
+
+import {Redirect} from '@docusaurus/router';
+
+const Home = () => {
+  return <Redirect to="/docs/claims-data-warehouse/mapping-guide" />;
+};


### PR DESCRIPTION
Adding a redirect so the old links to the setup guide e.g. those [here](https://tuva-health.github.io/the_tuva_project/#!/overview) will still work.  Dont have a lot of docusaurus experience but its working locally, lets see how it works in netlify.