### PR TITLE
Update documentation for using the new test_data_override variable

### DIFF
--- a/docs/getting-started/contributing.md
+++ b/docs/getting-started/contributing.md
@@ -62,7 +62,9 @@ Join our [Slack](https://join.slack.com/t/thetuvaproject/shared_invite/zt-16iz61
 The easiest way to test your changes is to use the dbt project inside the package called [integration_tests](https://github.com/tuva-health/the_tuva_project/tree/main/integration_tests).
 
 1. Set the project subdirectory to “integration_tests” if using dbt cloud or change directory (`cd integration_tests`) if using CLI.
-2. Update the vars in [integration_tests/dbt_project.yml](https://github.com/tuva-health/the_tuva_project/blob/main/integration_tests/dbt_project.yml) to the database and schema of your testing sources.
+2. *(Optional)* The project will run by default with synthetic demo data. To use your own data sources, update the vars in [integration_tests/dbt_project.yml](https://github.com/tuva-health/the_tuva_project/blob/main/integration_tests/dbt_project.yml): 
+   1. Set `test_data_override` to false  
+   2. Set `input_database` and `input_schema` to your testing sources
 3. Run `dbt deps`.
 4. Run `dbt build`.
 


### PR DESCRIPTION
Updates the contribution guide to include instructions on how to use the variable for running integration tests with synthetic demo data.