### PR TITLE
Fixing callout titles on use case page examples.

### DIFF
--- a/docs/use-cases/acute-inpatient.md
+++ b/docs/use-cases/acute-inpatient.md
@@ -315,6 +315,7 @@ CMS's readmission methodology excludes certain encounters from the calculation i
 
 <details>
   <summary>Disqualified Encounters</summary>
+
 Let's find how many encounters were disqualified.
 
 ```sql
@@ -326,6 +327,7 @@ where disqualified_encounter_flag = 1
 
 <details>
   <summary>Disqualification Reason</summary>
+  
 We can see the reason(s) why an encounter was disqualified by unpivoting the disqualification reason column.
 
 ```sql

--- a/docs/use-cases/medical-pmpm.md
+++ b/docs/use-cases/medical-pmpm.md
@@ -25,6 +25,7 @@ order by data_source
 
 <details>
   <summary>Trending PMPM by Service Category</summary>
+
 The pmpm table already breaks out pmpm by service category and groups it at the member month level.
 
 ```sql
@@ -36,6 +37,7 @@ order by 1
 
 <details>
   <summary>Trending PMPM by Claim Type</summary>
+
 Here we calculate PMPM manually by counting member months and joining payments by claim type to them.
 
 ```sql
@@ -87,6 +89,7 @@ order by mm.data_source
 
 <details>
   <summary>PMPM by Chronic Condition</summary>
+
 Here we calculate PMPM by chronic condition. Since members can and do have more than one chronic condition, payments and members months are duplicated. This is useful for comparing spend across chronic conditions, but should be used with caution given the duplication across conditions.
 
 ```sql
@@ -230,6 +233,7 @@ group by mm.data_source
 
 <details>
   <summary>Claims with Enrollment</summary>
+  
   The inverse of the above. Ideally this number will be 100%, but there could be extenuating reasons why not all claims have a corresponding member with enrollment.
 
   ```sql

--- a/docs/use-cases/pharmacy.md
+++ b/docs/use-cases/pharmacy.md
@@ -77,6 +77,7 @@ group by mm.data_source
 
 <details>
   <summary>Pharmacy Claims with Enrollment</summary>
+  
   The inverse of the above. Ideally this number will be 100%, but there could be extenuating reasons why not all claims have a corresponding member with enrollment.
 
   ```sql


### PR DESCRIPTION
Several callouts had 'Details' as the title while the actual title was the first line in the callout text. The issue was we needed to add a new blank line under the <summary></summary> tags to get the title to appear properly. This update fixed the issue in my local docusaurus preview.