### PR TITLE
fix broken tuvahealth website link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,7 +113,7 @@ const config = {
           // { to: 'manifesto', label: 'Manifesto', position: 'left' },
 
           {
-            href: 'https://www.tuvahealth.com',
+            href: 'https://tuvahealth.com',
             position: 'right',
             className: 'header-tuva-link',
             'aria-label': 'Tuva Health',


### PR DESCRIPTION
The www portion of the link is resulting in a broken link. Removed the www to fix.