### PR TITLE
Fix slack link on help page

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -3,6 +3,6 @@ id: help
 title: "Help"
 ---
 
-**Have a question?** If you have a question about anything to do with healthcare data or a question about the Tuva Project, the best thing to do is post in **#buildersask** in our [Slack community](https://join.slack.com/t/thetuvaproject/shared_invite/zt-16iz61187-G522Mc2WGA2mHF57e0il0Q).
+**Have a question?** If you have a question about anything to do with healthcare data or a question about the Tuva Project, the best thing to do is post in **#buildersask** in our [Slack community](https://join.slack.com/t/thetuvaproject/shared_invite/zt-35lhyb3as-moCo~~7A3el1oG1vSyIPHQ).
 
 **Have an issue or idea?**  If find a bug with the Tuva Project or have an idea for how to improve it, the best thing to do is create in issue in [Github](https://github.com/tuva-health/the_tuva_project).


### PR DESCRIPTION
fix expired slack link on the help page