### PR TITLE
fix typo in clone link

### DIFF
--- a/docs/data-quality/data-quality-dashboard.md
+++ b/docs/data-quality/data-quality-dashboard.md
@@ -72,7 +72,7 @@ always refer to the [project's README](https://github.com/tuva-health/tuva_dqi/b
 
 1.  **Clone the Repository:**
     ```bash
-    git clone [https://github.com/tuva-health/tuva_dqi.git](https://github.com/tuva-health/tuva_dqi.git)
+    git clone https://github.com/tuva-health/tuva_dqi.git
     cd tuva_dqi
     ```
 2.  **Set up a Virtual Environment:** (Recommended to avoid dependency conflicts)


### PR DESCRIPTION
Not markdown url, within code block