### PR TITLE
Update url for github hosted dbt docs

### DIFF
--- a/src/components/JsonDataTable.js
+++ b/src/components/JsonDataTable.js
@@ -93,8 +93,8 @@ export function JsonDataTable({ jsonPath, columns = tableHeaders }) {
     if (ExecutionEnvironment.canUseDOM) {
       const fetchData = async () => {
         try {
-          const responseMan = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/main/docs/manifest.json");
-          const responseCat = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/main/docs/catalog.json");
+          const responseMan = await fetch("https://tuva-health.github.io/tuva/manifest.json");
+          const responseCat = await fetch("https://tuva-health.github.io/tuva/catalog.json");
           const jsonDataMan = await responseMan.json();
           const jsonDataCat = await responseCat.json();
           const data = parseJsonData(jsonDataMan, jsonDataCat, jsonPath);

--- a/src/components/JsonTable.js
+++ b/src/components/JsonTable.js
@@ -6,10 +6,10 @@ export function JsonTable({  jsonPath }) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        // const responseMan = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/main/docs/manifest.json");
-        // const responseCat = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/main/docs/catalog.json");
-        const responseMan = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/terminology_test/docs/manifest.json");
-        const responseCat = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/terminology_test/docs/catalog.json");
+        // const responseMan = await fetch("https://tuva-health.github.io/tuva/manifest.json");
+        // const responseCat = await fetch("https://tuva-health.github.io/tuva/catalog.json");
+        const responseMan = await fetch("https://tuva-health.github.io/tuva/manifest.json");
+        const responseCat = await fetch("https://tuva-health.github.io/tuva/catalog.json");
         // console.log('ResponseMan: ', responseMan)
         // console.log('ResponseCat: ', responseCat)
         const jsonDataMan = await responseMan.json();

--- a/src/components/JsonTableScroll.js
+++ b/src/components/JsonTableScroll.js
@@ -8,10 +8,10 @@ export function JsonTableScroll({  jsonPath, tableHeight = "600"  }) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        // const responseMan = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/main/docs/manifest.json");
-        // const responseCat = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/main/docs/catalog.json");
-        const responseMan = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/terminology_test/docs/manifest.json");
-        const responseCat = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/terminology_test/docs/catalog.json");
+        // const responseMan = await fetch("https://tuva-health.github.io/tuva/manifest.json");
+        // const responseCat = await fetch("https://tuva-health.github.io/tuva/catalog.json");
+        const responseMan = await fetch("https://tuva-health.github.io/tuva/manifest.json");
+        const responseCat = await fetch("https://tuva-health.github.io/tuva/catalog.json");
         // console.log('ResponseMan: ', responseMan)
         // console.log('ResponseCat: ', responseCat)
         const jsonDataMan = await responseMan.json();


### PR DESCRIPTION
Updated URL of dbt docs (manifest and catalog) to new location. These docs are now being uploaded to Github artifacts following [PR 945](https://github.com/tuva-health/tuva/pull/945) which automates the creation of dbt docs, rather than the old [tuva/docs](https://github.com/tuva-health/tuva/tree/main/docs) folder.