### PR TITLE
Update mapping-guide.md

### DIFF
--- a/docs/getting-started/mapping-guide.md
+++ b/docs/getting-started/mapping-guide.md
@@ -560,7 +560,7 @@ A new patient identifier field named `person_id` has been added to the Tuva data
 <details>
   <summary>Primary Key</summary>
 
-- The primary key for the pharmacy_claim table is person_id, member_id, enrollment_start_date, enrollment_end_date, and data_source.  
+- The primary key for the eligibility table is person_id, member_id, enrollment_start_date, enrollment_end_date, and data_source.  
 - There are two commonly used data formats for eligibility (also known as enrollment) data: the eligibility span format and the member month format.
 - The eligibility span format has one record per member eligibility span.  An eligibility span is a time period when a member was enrolled with and therefore had insurance coverage by a health plan.  An eligibility span has a start date and an end date.  A person can have multiple eligibility spans.
 - The member month format has one record per member per month of enrollment.  For example, a person with a single eligibility span from 1/1/2020 through 3/31/2020 would have a single eligibility span record, but 3 member month records, one for each month.


### PR DESCRIPTION
Changed pharmacy_claim to eligibility.

Note: The primary key information in mapping-guide.md doesn't match the primary key information for eligibility in input-layer.md (https://github.com/tuva-health/docs/blob/77a270b0f6348faf9a8a1d42d9aece23ece84db6/docs/connectors/input-layer.md#L4). There, the primary key list also includes payer, plan, and data_source.