### PR TITLE
Update url for github hosted dbt docs

### DIFF
--- a/src/components/JsonDataTableNoTerm.js
+++ b/src/components/JsonDataTableNoTerm.js
@@ -93,8 +93,8 @@ export function JsonDataTableNoTerm({ jsonPath, columns = tableHeadersNoTerm }) 
     if (ExecutionEnvironment.canUseDOM) {
       const fetchData = async () => {
         try {
-          const responseMan = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/main/docs/manifest.json");
-          const responseCat = await fetch("https://raw.githubusercontent.com/tuva-health/the_tuva_project/main/docs/catalog.json");
+          const responseMan = await fetch("https://tuva-health.github.io/tuva/manifest.json");
+          const responseCat = await fetch("https://tuva-health.github.io/tuva/catalog.json");
           const jsonDataMan = await responseMan.json();
           const jsonDataCat = await responseCat.json();
           const data = parseJsonData(jsonDataMan, jsonDataCat, jsonPath);


### PR DESCRIPTION
Missed a JsonDataTable file in src/components/ when updating the URL of dbt docs hosted in Github artifacts. This fixes the missing columns on some terminology pages. For example:

https://thetuvaproject.com/terminology/provider
https://deploy-preview-441--thetuvaproject.netlify.app/terminology/provider