### PR TITLE
Docs/tuva 186 ansi terminology update docs

### DIFF
--- a/docs/terminology/ansi-fips-state.md
+++ b/docs/terminology/ansi-fips-state.md
@@ -26,17 +26,15 @@ ANSI FIPS State code is a standarized two-digit numeric codes that represents ea
 
 ## Tuva Seed File Update Process
 
-Note: This is the maintenance process used by Tuva to maintain the current codeset in the Tuva package. Tuva users do not need to complete this step unless they are leveraging a different version of codes or are no longer updating to the current version of the project, but need an updated terminology set. 
-
 **The below description outlines the update process as it existed prior to changes in the ANSI site no longer publishing updates to this code set. Updates are currently on hold until a new source can be identified**
 
 1. Navigate to the [ANSI Census Website](https://www.census.gov/library/reference/code-lists/ansi.html)
 2. Select the latest available census year
 3. Navigate to **State and State Equivalent** section
-4. Click to the available data file link to download the latest avilable data
+4. Click to the available data file link to download the latest available data
 5. Copy and paste the code list into any text editor
 6. Find and replace all "|" with "," and save in a CSV file format
-7. Map the headers as follow
+7. Map the headers as follow:
 
     | Source Header | Expected Header              |
     |---------------|------------------------------|

--- a/docs/terminology/ansi-fips-state.md
+++ b/docs/terminology/ansi-fips-state.md
@@ -11,3 +11,54 @@ import { JsonDataTableNoTerm } from '@site/src/components/JsonDataTableNoTerm';
 <JsonDataTable  jsonPath="nodes.seed\.the_tuva_project\.reference_data__ansi_fips_state.columns" />
 
 <a href="https://tuva-public-resources.s3.amazonaws.com/versioned_terminology/latest/ansi_fips_state.csv_0_0_0.csv.gz">Download CSV</a>
+
+---
+
+## What are ANSI FIPS State Code?
+
+American National Standards Insititute (ANSI) codes are standarized numeric or alphabetic codes whose documentation is issued by ANSI to ensure the uniform indentificaiton of geographic entities through all government agencies. 
+
+Federal Information Processing Standards (FIPS) is a set of publically announced standards developed by the U.S. Federal Government for use in computer system by non-military government agencies and contractors. FIPS ensures standardized security and interportability across government system. 
+
+ANSI FIPS State code is a standarized two-digit numeric codes that represents each U.S. state and certain territories. 
+
+---
+
+## Tuva Seed File Update Process
+
+Note: This is the maintenance process used by Tuva to maintain the current codeset in the Tuva package. Tuva users do not need to complete this step unless they are leveraging a different version of codes or are no longer updating to the current version of the project, but need an updated terminology set. 
+
+**The below description outlines the update process as it existed prior to changes in the ANSI site no longer publishing updates to this code set. Updates are currently on hold until a new source can be identified**
+
+1. Navigate to the [ANSI Census Website](https://www.census.gov/library/reference/code-lists/ansi.html)
+2. Select the latest available census year
+3. Navigate to **State and State Equivalent** section
+4. Click to the available data file link to download the latest avilable data
+5. Copy and paste the code list into any text editor
+6. Find and replace all "|" with "," and save in a CSV file format
+7. Map the headers as follow
+
+    | Source Header | Expected Header              |
+    |---------------|------------------------------|
+    | STATEFP       | ANSI_FIPS_STATE_CODE         |
+    | STATE         | ANSI_FIPS_STATE_ABBREVIATION |
+    | STATE_NAME    | ANSI_FIPS_STATE_NAME         |
+    
+8. Import the CSV file into any data warehouse
+9. Upload the CSV file from the data warehouse to S3 (credentials with write permissions to the S3 bucket are required)
+```sql
+-- example code for Snowflake
+copy into s3://tuva-public-resources/terminology/anis_fips_state.csv
+from [table_created_in_step_8]
+file_format = (type = csv field_optionally_enclosed_by = '"')
+storage_integration = [integration_with_s3_write_permissions]
+OVERWRITE = TRUE;
+```
+10. Create a branch in [docs](https://github.com/tuva-health/docs).  Update the `last_updated` column in the table above with the current date
+11. Submit a pull request
+
+**The below steps are only required if the headers of the file need to be changed. The Tuva Project does not store the contents of the terminology file in GitHub.**
+
+1. Create a branch in [The Tuva Project](https://github.com/tuva-health/tuva)
+2. Copy and paste the updated header into the [ANSI FIPS State File](https://github.com/Nabin-Maitri/tuva/blob/main/seeds/reference_data/reference_data__ansi_fips_state.csv)
+3. Submit a pull request

--- a/docs/terminology/ansi-fips-state.md
+++ b/docs/terminology/ansi-fips-state.md
@@ -36,7 +36,7 @@ ANSI FIPS State code is a standarized two-digit numeric codes that represents ea
 6. Find and replace all "|" with "," and save in a CSV file format
 7. Map the headers as follow:
 
-    | Source Header | Expected Header              |
+    | Source Column | Tuva Column                  |
     |---------------|------------------------------|
     | STATEFP       | ANSI_FIPS_STATE_CODE         |
     | STATE         | ANSI_FIPS_STATE_ABBREVIATION |

--- a/docs/terminology/fips-county.md
+++ b/docs/terminology/fips-county.md
@@ -34,8 +34,8 @@ digit is the block group FIPS code.
 7. Format the file
     - Encode and Decode the non regular characters like "â€" to plain text
     - Concat `STATEFP` and `COUNTYFP` from raw data to generate `FIPS_CODE` field
-    - Truncate last part of `COUNTYNAME` field and map to `COUNTY` field and `STATE` to `STATE` itself.
-
+    - Truncate last part of `COUNTYNAME` field and map to `COUNTY` field
+    
 ***Note**: you can use the below script to format the file as said in **number 7.***
 ```python
 import re
@@ -67,12 +67,12 @@ def format_columns(raw_df):
 if __name__ == "__main__":
     input_file_location= "your csv file path"
     output_file_location = "your processed csv file path"
+    cleaning_list = ['parish', 'borough', 'census area', 'county', 'city and borough', 'municipio', 'island', 'municipality']
     read_df = pd.read_csv(f'{input_file_location}', dtype=str)
     column_formatted_df = format_columns(raw_df = read_df)
     for col in column_formatted_df.select_dtypes(include=['object']).columns:
         column_formatted_df[col] = column_formatted_df[col].apply(fix_and_normalize)
 
-    cleaning_list = ['parish', 'borough', 'census area', 'county', 'city and borough', 'municipio', 'island', 'municipality']
     # regex matches optional whitespace and trailing dots followed by any word from cleaning_list at the end of a string.
     pattern = r'\s*(?:{})(?:\s*\.*)?\s*$'.format("|".join(map(re.escape, cleaning_list)))
     column_formatted_df['COUNTY'] = column_formatted_df['COUNTY'].str.replace(pattern, '', regex=True, flags=re.IGNORECASE)

--- a/docs/terminology/fips-county.md
+++ b/docs/terminology/fips-county.md
@@ -19,3 +19,39 @@ digit is the block group FIPS code.
 <JsonDataTable  jsonPath="nodes.seed\.the_tuva_project\.reference_data__fips_county.columns" />
 
 <a href="https://tuva-public-resources.s3.amazonaws.com/versioned_terminology/latest/fips_county.csv_0_0_0.csv.gz">Download CSV</a>
+
+---
+## Tuva Seed File Update Process
+
+Note: This is the maintenance process used by Tuva to maintain the current codeset in the Tuva package. Tuva users do not need to complete this step unless they are leveraging a different version of codes or are no longer updating to the current version of the project, but need an updated terminology set. 
+
+**The below description outlines the update process as it existed prior to changes in the ANSI site no longer publishing updates to this code set. Updates are currently on hold until a new source can be identified**
+
+1. Navigate to the [ANSI Census Website](https://www.census.gov/library/reference/code-lists/ansi.html)
+2. Select the latest available census year
+3. Navigate to **County and County Equivalent Entities** section
+4. From Dropdown section, select **United State**
+5. Copy and paste the code list into any text editor
+6. Find and replace all "|" with "," and save in a CSV file format
+    - Encode and Decode the non regular characters like "â€" to plain text
+7. Concat `STATEFP` and `COUNTYFP` from raw data to generate `FIPS_CODE` field
+8. Truncate last part of `COUNTYNAME` field and map to `COUNTY` field and `STATE` to `STATE` itself.
+
+9. Import the CSV file into any data warehouse
+10. Upload the CSV file from the data warehouse to S3 (credentials with write permissions to the S3 bucket are required)
+```sql
+-- example code for Snowflake
+copy into s3://tuva-public-resources/terminology/fips_county.csv
+from [table_created_in_step_8]
+file_format = (type = csv field_optionally_enclosed_by = '"')
+storage_integration = [integration_with_s3_write_permissions]
+OVERWRITE = TRUE;
+```
+11. Create a branch in [docs](https://github.com/tuva-health/docs).  Update the `last_updated` column in the table above with the current date
+12. Submit a pull request
+
+**The below steps are only required if the headers of the file need to be changed. The Tuva Project does not store the contents of the terminology file in GitHub.**
+
+1. Create a branch in [The Tuva Project](https://github.com/tuva-health/tuva)
+2. Copy and paste the updated header into the [ANSI FIPS County File](https://github.com/Nabin-Maitri/tuva/blob/main/seeds/reference_data/reference_data__fips_county.csv)
+3. Submit a pull request

--- a/docs/terminology/fips-county.md
+++ b/docs/terminology/fips-county.md
@@ -23,22 +23,64 @@ digit is the block group FIPS code.
 ---
 ## Tuva Seed File Update Process
 
-Note: This is the maintenance process used by Tuva to maintain the current codeset in the Tuva package. Tuva users do not need to complete this step unless they are leveraging a different version of codes or are no longer updating to the current version of the project, but need an updated terminology set. 
-
 **The below description outlines the update process as it existed prior to changes in the ANSI site no longer publishing updates to this code set. Updates are currently on hold until a new source can be identified**
 
 1. Navigate to the [ANSI Census Website](https://www.census.gov/library/reference/code-lists/ansi.html)
 2. Select the latest available census year
 3. Navigate to **County and County Equivalent Entities** section
-4. From Dropdown section, select **United State**
+4. From Dropdown section, select **United States**
 5. Copy and paste the code list into any text editor
 6. Find and replace all "|" with "," and save in a CSV file format
+7. Format the file
     - Encode and Decode the non regular characters like "â€" to plain text
-7. Concat `STATEFP` and `COUNTYFP` from raw data to generate `FIPS_CODE` field
-8. Truncate last part of `COUNTYNAME` field and map to `COUNTY` field and `STATE` to `STATE` itself.
+    - Concat `STATEFP` and `COUNTYFP` from raw data to generate `FIPS_CODE` field
+    - Truncate last part of `COUNTYNAME` field and map to `COUNTY` field and `STATE` to `STATE` itself.
 
-9. Import the CSV file into any data warehouse
-10. Upload the CSV file from the data warehouse to S3 (credentials with write permissions to the S3 bucket are required)
+***Note**: you can use the below script to format the file as said in **number 7.***
+```python
+import re
+import pandas as pd
+import unicodedata
+
+def fix_and_normalize(val):
+    '''
+        Normalize the string to NFKD form, encode to latin1, decode to utf-8, then encode to ascii ignoring errors
+    '''
+    if isinstance(val, str):
+        try:
+            return unicodedata.normalize('NFKD', val.encode('latin1').decode('utf-8')).encode('ascii', 'ignore').decode('ascii')
+        except Exception:
+            return val
+    return val
+
+def format_columns(raw_df):
+    # select only the necessary columns
+    raw_df = raw_df[['STATEFP', 'COUNTYFP', 'COUNTYNAME', 'STATE']]
+    # concats `STATEFP` and `COUNTYFP` to generate `FIPS_CODE`
+    raw_df['FIPS_CODE'] = raw_df['STATEFP'] + '' + raw_df['COUNTYFP']
+    raw_df.rename(columns={'COUNTYNAME':'COUNTY'}, inplace=True)
+    raw_df.drop(['STATEFP', 'COUNTYFP'], axis=1, inplace=True)
+    column_formatted_df = raw_df[['FIPS_CODE', 'COUNTY', 'STATE']]
+    return column_formatted_df
+
+
+if __name__ == "__main__":
+    input_file_location= "your csv file path"
+    output_file_location = "your processed csv file path"
+    read_df = pd.read_csv(f'{input_file_location}', dtype=str)
+    column_formatted_df = format_columns(raw_df = read_df)
+    for col in column_formatted_df.select_dtypes(include=['object']).columns:
+        column_formatted_df[col] = column_formatted_df[col].apply(fix_and_normalize)
+
+    cleaning_list = ['parish', 'borough', 'census area', 'county', 'city and borough', 'municipio', 'island', 'municipality']
+    # regex matches optional whitespace and trailing dots followed by any word from cleaning_list at the end of a string.
+    pattern = r'\s*(?:{})(?:\s*\.*)?\s*$'.format("|".join(map(re.escape, cleaning_list)))
+    column_formatted_df['COUNTY'] = column_formatted_df['COUNTY'].str.replace(pattern, '', regex=True, flags=re.IGNORECASE)
+    column_formatted_df.to_csv(f'{output_file_location}', index=False, encoding='utf-8', sep=',')
+
+```
+8. Import the CSV file into any data warehouse
+9. Upload the CSV file from the data warehouse to S3 (credentials with write permissions to the S3 bucket are required)
 ```sql
 -- example code for Snowflake
 copy into s3://tuva-public-resources/terminology/fips_county.csv
@@ -47,8 +89,8 @@ file_format = (type = csv field_optionally_enclosed_by = '"')
 storage_integration = [integration_with_s3_write_permissions]
 OVERWRITE = TRUE;
 ```
-11. Create a branch in [docs](https://github.com/tuva-health/docs).  Update the `last_updated` column in the table above with the current date
-12. Submit a pull request
+10. Create a branch in [docs](https://github.com/tuva-health/docs).  Update the `last_updated` column in the table above with the current date
+11. Submit a pull request
 
 **The below steps are only required if the headers of the file need to be changed. The Tuva Project does not store the contents of the terminology file in GitHub.**
 

--- a/docs/terminology/overview.md
+++ b/docs/terminology/overview.md
@@ -48,7 +48,7 @@ The **Last Updated** date in the table below is the date the codeset was release
       <td><a href="../terminology/ansi-fips-state">ANSI FIPS State</a></td>
       <td>ANSI</td>
       <td></td>
-      <td></td>
+      <td>8/7/2025</td>
       <td><a href="https://tuva-public-resources.s3.amazonaws.com/versioned_terminology/latest/ansi_fips_state.csv_0_0_0.csv.gz">Link</a></td>
     </tr>
     <tr>
@@ -116,9 +116,9 @@ The **Last Updated** date in the table below is the date the codeset was release
     </tr>
     <tr>
       <td><a href="../terminology/fips-county">FIPS County</a></td>
-      <td>Tuva</td>
+      <td>ANSI</td>
       <td></td>
-      <td>4/19/2022</td>
+      <td>8/7/2025</td>
       <td><a href="https://tuva-public-resources.s3.amazonaws.com/versioned_terminology/latest/fips_county.csv_0_0_0.csv.gz">Link</a></td>
     </tr>
     <tr>
@@ -319,9 +319,9 @@ The **Last Updated** date in the table below is the date the codeset was release
     </tr>
     <tr>
       <td><a href="../terminology/ssa-state-fips">SSA State FIPS</a></td>
-      <td>Social Security Administration</td>
-      <td></td>
-      <td></td>
+      <td>Social Security Administration(National Bureau of Economic Research)</td>
+      <td>Update Anually</td>
+      <td>8/7/2025</td>
       <td><a href="https://tuva-public-resources.s3.amazonaws.com/versioned_terminology/latest/ssa_fips_state.csv_0_0_0.csv.gz">Link</a></td>
     </tr>
     <tr>

--- a/docs/terminology/overview.md
+++ b/docs/terminology/overview.md
@@ -318,10 +318,10 @@ The **Last Updated** date in the table below is the date the codeset was release
       <td><a></a></td>
     </tr>
     <tr>
-      <td><a href="../terminology/ssa-state-fips">SSA State FIPS</a></td>
-      <td>Social Security Administration(National Bureau of Economic Research)</td>
-      <td>Update Anually</td>
-      <td>8/7/2025</td>
+      <td><a href="../terminology/ssa-state-fips">SSA FIPS State</a></td>
+      <td>Social Security Administration</td>
+      <td></td>
+      <td></td>
       <td><a href="https://tuva-public-resources.s3.amazonaws.com/versioned_terminology/latest/ssa_fips_state.csv_0_0_0.csv.gz">Link</a></td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR is created intending to update the terminology set for `ANSI FIPS STATE` and `FIPS County` terminology set.
Updated seeds are in following S3 Bucket location.

ANSI_FIPS_STATE: `s3://tuva-public-resources-snowflake/versioned_terminology/ansi_fips_state.csv_0_0_0.csv.gz`
FIPS_COUNTY: `s3://tuva-public-resources-snowflake/versioned_terminology/fips_county.csv_0_0_0.csv.gz`

Here, the maintainer for `FIPS COUNTY` has been updated to `ANSI` from `TUVA`

PS: Please sync the data from s3 bucket: `tuva-public-resources-snowflake` to the production bucket